### PR TITLE
update flatbuffers and flatcc versions, fix potential integer overflow in segments exporter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ shared_memory = "0.12"
 thiserror = "1"
 which = "4"
 url = "2.2"
-flatbuffers = "23.1.21"
+flatbuffers = "24.3.25"
 
 [build-dependencies]
-flatcc = "23.1.21"
+flatcc = "24.3.25"
 
 [dev-dependencies]
 fugue = { version = "0.2", features = ["db"], default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,18 +13,18 @@ fixed-u128 = ["fugue-db/fixed-u128"]
 
 [dependencies]
 fugue-db = { version = "0.2", default-features = false }
-iset = "0.2"
-itertools = "0.10"
+iset = "0.3"
+itertools = "0.13"
 md5 = "0.7"
-sha2 = "0.9"
-memmap = "0.7"
-r2pipe = "0.6"
+sha2 = "0.10"
+memmap2 = "0.9"
+r2pipe = "0.7"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 shared_memory = "0.12"
 thiserror = "1"
-which = "4"
-url = "2.2"
+which = "6"
+url = "2.5"
 flatbuffers = "24.3.25"
 
 [build-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fugue-radare"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 license = "MIT"
 description = "A binary analysis framework written in Rust"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -223,7 +223,7 @@ struct Function<'d> {
 }
 
 pub enum Backing {
-    M(File, memmap::Mmap),
+    M(File, memmap2::Mmap),
     S(shared_memory::Shmem),
 }
 
@@ -269,7 +269,7 @@ impl<'db> RadareExporter<'db> {
             let path = path.strip_prefix("file://").unwrap_or(&path);
             let file = File::open(path).map_err(Error::InvalidImportFile)?;
 
-            let mm = unsafe { memmap::Mmap::map(&file) }.map_err(Error::CannotMapFile)?;
+            let mm = unsafe { memmap2::Mmap::map(&file) }.map_err(Error::CannotMapFile)?;
 
             Backing::M(file, mm)
         };


### PR DESCRIPTION
This update contains minor changes to actualise the library and fixes potential integer overflow.

In the latest version of rizin (`rizin 0.7.3`) `vaddr` for `.comment` and `.shstrtab` will be `0xffffffffffffffff` for `true` test case:

```
[0x00002130]> iS
paddr      size   vaddr      vsize  align perm name               type       flags
-------------------------------------------------------------------------------------------
...
0x00008e68 0x180  0x00009e68 0x180  0x0   -rw- .got               PROGBITS   write,alloc
0x00009000 0x80   0x0000a000 0x80   0x0   -rw- .data              PROGBITS   write,alloc
0x00009080 0x0    0x0000a080 0x198  0x0   -rw- .bss               NOBITS     write,alloc
0x00009080 0x4c   ---------- 0x4c   0x0   ---- .comment           PROGBITS   merge,strings
0x000090cc 0xf7   ---------- 0xf7   0x0   ---- .shstrtab          STRTAB
```

```json
{
  "name": ".comment",
  "size": 76,
  "vsize": 76,
  "perm": "----",
  "type": "PROGBITS",
  "flags": [
    "merge",
    "strings"
  ],
  "paddr": 36992,
  "vaddr": 18446744073709551615
},
{
  "name": ".shstrtab",
  "size": 247,
  "vsize": 247,
  "perm": "----",
  "type": "STRTAB",
  "paddr": 37068,
  "vaddr": 18446744073709551615
}
```

In the latest version of radare2 (`radare2 5.9.6`) `vaddr` for `.comment` and `.shstrtab` will be `0`:

```json
{
  "name": ".comment",
  "size": 76,
  "vsize": 76,
  "type": "PROGBITS",
  "perm": "----",
  "paddr": 36992,
  "vaddr": 0
},
{
  "name": ".shstrtab",
  "size": 247,
  "vsize": 247,
  "type": "STRTAB",
  "perm": "----",
  "paddr": 37068,
  "vaddr": 0
}
```